### PR TITLE
Fix -r option in security-audit script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,19 +66,21 @@ shell: build
 
 # Security Audit
 
+SecurityAuditRole=AssumableSecurityAuditRole
+
 security-audit-accounts:
 ifndef Accounts
 	$(error Accounts is undefined)
 endif
 	echo $(Accounts)
 	docker-compose build aws-baseline
-	docker-compose run aws-baseline ./scripts/security-audit -p $(Accounts)
+	docker-compose run aws-baseline ./scripts/security-audit -p -r $(SecurityAuditRole) $(Accounts)
 
 clean-reports:
 	rm -fr reports
 
 security-audit-all: build clean-reports
-	docker-compose run aws-baseline ./scripts/security-audit -p
+	docker-compose run aws-baseline ./scripts/security-audit -p -r $(SecurityAuditRole)
 
 security-audit-docker-with-rebuild: rebuild-baseline security-audit-all
 

--- a/scripts/security-audit
+++ b/scripts/security-audit
@@ -14,7 +14,7 @@ SECONDS=0
 
 while getopts "r:pmd:" opt; do
     case "$opt" in
-        r) AUDIT_ROLE='$OPTARG' ;;
+        r) AUDIT_ROLE="$OPTARG" ;;
         p) PARALLEL='TRUE' ;;
         d) ASSUME_DURATION="-d $OPTARG" ;;
         m) ASSUME_MFA="-m" ;;


### PR DESCRIPTION
Patch also adds a variable to the top-level Makefile to make use of the -r option