### PR TITLE
Fix failing 07-config-rules stack set deployment in ap-northeast-3

### DIFF
--- a/stack-sets/07-config-rules/config-rules.template.yaml
+++ b/stack-sets/07-config-rules/config-rules.template.yaml
@@ -3,6 +3,7 @@ Mappings:
     {% for Region in AWSRegions %}
     {{Region}}:
       Enabled: {% if Region in EnabledRegions %}true{%else%}false{%endif%}
+      GuardDuty: {% if Region in GuardDutyUnavailableRegions %}false{%else%}true{%endif%}
     {% endfor %}
 
 Parameters:
@@ -17,6 +18,7 @@ Parameters:
 Conditions:
   IsEnabledRegion: !Equals [!FindInMap ['RegionMap', !Ref 'AWS::Region', 'Enabled'], 'true']
   IsDisabledRegion: !Equals [!FindInMap ['RegionMap', !Ref 'AWS::Region', 'Enabled'], 'false']
+  IsGuardDutyRegion: !Equals [!FindInMap ['RegionMap', !Ref 'AWS::Region', 'GuardDuty'], 'true']
   IsGlobalRegion: !Equals [!Ref 'AWS::Region', !Ref GlobalConfigRegion]
   IsGlobalMainAccountRegion:
     Fn::And:
@@ -25,6 +27,15 @@ Conditions:
   IsLocalConfigRegion: !Not [ !Equals [!Ref 'AWS::Region', !Ref GlobalConfigRegion] ]
   IsMainAccount: !Equals [!Ref 'AWS::AccountId', !Ref MainAccount]
   IsSubAccount: !Not [!Equals [!Ref 'AWS::AccountId', !Ref MainAccount]]
+  IsMainAccountAndGuardDutyRegion:
+    Fn::And:
+      - !Condition IsMainAccount
+      - !Condition IsGuardDutyRegion
+  IsSubAccountAndGuardDutyRegion:
+    Fn::And:
+      - !Condition IsSubAccount
+      - !Condition IsGuardDutyRegion
+
 
 Resources:
   {% for Rule, Resource in EnabledConfigRules.items() %}
@@ -60,7 +71,7 @@ Resources:
   {% endfor %}
 
   GuardDutyEnabledAndCentralized:
-    Condition: IsSubAccount
+    Condition: IsSubAccountAndGuardDutyRegion
     Type: AWS::Config::ConfigRule
     Properties:
       ConfigRuleName: "GUARDDUTY_ENABLED_CENTRALIZED"
@@ -71,7 +82,7 @@ Resources:
         SourceIdentifier: "GUARDDUTY_ENABLED_CENTRALIZED"
 
   GuardDutyMainAccountEnabled:
-    Condition: IsMainAccount
+    Condition: IsMainAccountAndGuardDutyRegion
     Type: AWS::Config::ConfigRule
     Properties:
       ConfigRuleName: "GUARDDUTY_ENABLED_CENTRALIZED"

--- a/stack-sets/07-config-rules/stack-set.config.yaml
+++ b/stack-sets/07-config-rules/stack-set.config.yaml
@@ -10,14 +10,18 @@ region: us-east-1
 vars:
   EnabledRegions:
     - us-east-1
+  GuardDutyUnavailableRegions:
+    - ap-northeast-3
   EnabledConfigRules:
     EIP_ATTACHED: AWS::EC2::EIP
     INCOMING_SSH_DISABLED: AWS::EC2::SecurityGroup
     RDS_INSTANCE_PUBLIC_ACCESS_CHECK: AWS::RDS::DBInstance
     CLOUD_TRAIL_CLOUD_WATCH_LOGS_ENABLED: AWS::CloudTrail::Trail
     VPC_FLOW_LOGS_ENABLED: AWS::EC2::VPC
-    S3_BUCKET_PUBLIC_READ_PROHIBITED: ['AWS::S3::Bucket', 'AWS::S3::AccountPublicAccessBlock']
-    S3_BUCKET_PUBLIC_WRITE_PROHIBITED: ['AWS::S3::Bucket', 'AWS::S3::AccountPublicAccessBlock']
+    S3_BUCKET_PUBLIC_READ_PROHIBITED:
+      ["AWS::S3::Bucket", "AWS::S3::AccountPublicAccessBlock"]
+    S3_BUCKET_PUBLIC_WRITE_PROHIBITED:
+      ["AWS::S3::Bucket", "AWS::S3::AccountPublicAccessBlock"]
 capabilities:
   - CAPABILITY_IAM
 tags:


### PR DESCRIPTION
GuardDuty is not available in ap-northeast-3 any GuarDuty related config items will cause the stack sets to fail to deploy to this region. 

This pull request adds a to the region map whether or not GuardDuty is available for a region and updates the conditions to only deploy GuarDuty related configs to regions where GuardDuty is available. 